### PR TITLE
Add Jest tests for category management API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use node:23-alpine as the base image
+FROM node:23-alpine
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose port 3000
+EXPOSE 3000
+
+# Start the application
+CMD ["npm", "start"]

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
+  moduleFileExtensions: ['ts', 'js', 'json', 'node'],
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+};

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: category-api-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: category-api
+  template:
+    metadata:
+      labels:
+        app: category-api
+    spec:
+      containers:
+        - name: category-api
+          image: category-api:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: MONGO_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongo-secret
+                  key: mongo-uri

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: category-api-service
+spec:
+  selector:
+    app: category-api
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000
+  type: LoadBalancer

--- a/postman_collection.json
+++ b/postman_collection.json
@@ -1,0 +1,116 @@
+{
+  "info": {
+    "name": "Category Management API",
+    "_postman_id": "12345-67890-abcdef",
+    "description": "Postman collection to test all the APIs of the Category Management API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Create Category",
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": JSON.stringify({
+            "name": "New Category",
+            "parentId": "60d5ec49f8d2c2a1d4f8b0e1"
+          })
+        },
+        "url": {
+          "raw": "http://localhost:3000/api/categories",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "api",
+            "categories"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Update Category",
+      "request": {
+        "method": "PUT",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": JSON.stringify({
+            "name": "Updated Category"
+          })
+        },
+        "url": {
+          "raw": "http://localhost:3000/api/categories/60d5ec49f8d2c2a1d4f8b0e1",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "api",
+            "categories",
+            "60d5ec49f8d2c2a1d4f8b0e1"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Delete Category",
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/api/categories/60d5ec49f8d2c2a1d4f8b0e1",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "api",
+            "categories",
+            "60d5ec49f8d2c2a1d4f8b0e1"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Get Categories Tree",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:3000/api/categories/tree",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "3000",
+          "path": [
+            "api",
+            "categories",
+            "tree"
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/src/controllers/categoryController.test.ts
+++ b/src/controllers/categoryController.test.ts
@@ -1,0 +1,93 @@
+import request from 'supertest';
+import app from '../app';
+import mongoConnection from '../config/dbConfig';
+import CategoryModel from '../models/categoryModel';
+
+beforeAll(async () => {
+  await mongoConnection.connect();
+});
+
+afterAll(async () => {
+  await CategoryModel.deleteMany({});
+  await mongoConnection.disconnect();
+});
+
+describe('CategoryController', () => {
+  let categoryId: string;
+
+  describe('POST /api/categories', () => {
+    it('should create a new category', async () => {
+      const response = await request(app)
+        .post('/api/categories')
+        .send({ name: 'Electronics' });
+
+      expect(response.status).toBe(201);
+      expect(response.body.name).toBe('Electronics');
+      categoryId = response.body._id;
+    });
+
+    it('should return an error if category creation fails', async () => {
+      const response = await request(app)
+        .post('/api/categories')
+        .send({});
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBeDefined();
+    });
+  });
+
+  describe('PUT /api/categories/:id', () => {
+    it('should update an existing category', async () => {
+      const response = await request(app)
+        .put(`/api/categories/${categoryId}`)
+        .send({ name: 'Updated Electronics' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.name).toBe('Updated Electronics');
+    });
+
+    it('should return an error if category update fails', async () => {
+      const response = await request(app)
+        .put('/api/categories/invalidId')
+        .send({ name: 'Invalid Update' });
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBeDefined();
+    });
+  });
+
+  describe('DELETE /api/categories/:id', () => {
+    it('should delete an existing category', async () => {
+      const response = await request(app).delete(`/api/categories/${categoryId}`);
+
+      expect(response.status).toBe(204);
+    });
+
+    it('should return an error if category deletion fails', async () => {
+      const response = await request(app).delete('/api/categories/invalidId');
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBeDefined();
+    });
+  });
+
+  describe('GET /api/categories/tree', () => {
+    it('should retrieve the category tree', async () => {
+      const response = await request(app).get('/api/categories/tree');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toBeInstanceOf(Array);
+    });
+
+    it('should return an error if category tree retrieval fails', async () => {
+      jest.spyOn(CategoryModel, 'find').mockImplementationOnce(() => {
+        throw new Error('Database error');
+      });
+
+      const response = await request(app).get('/api/categories/tree');
+
+      expect(response.status).toBe(500);
+      expect(response.body.error).toBeDefined();
+    });
+  });
+});

--- a/src/services/categoryService.test.ts
+++ b/src/services/categoryService.test.ts
@@ -1,0 +1,105 @@
+import mongoose from 'mongoose';
+import { createCategory, updateCategory, deleteCategory, getTree } from './categoryService';
+import CategoryModel from '../models/categoryModel';
+
+jest.mock('../models/categoryModel');
+
+describe('Category Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createCategory', () => {
+    it('should create a category successfully', async () => {
+      const categoryData = { name: 'Test Category' };
+      const savedCategory = { _id: '1', ...categoryData, save: jest.fn() };
+      (CategoryModel as any).mockImplementation(() => savedCategory);
+
+      const result = await createCategory(categoryData);
+
+      expect(result).toEqual(savedCategory);
+      expect(savedCategory.save).toHaveBeenCalled();
+    });
+
+    it('should handle error during category creation', async () => {
+      const categoryData = { name: 'Test Category' };
+      (CategoryModel as any).mockImplementation(() => {
+        throw new Error('Error creating category');
+      });
+
+      await expect(createCategory(categoryData)).rejects.toThrow('Error creating category');
+    });
+  });
+
+  describe('updateCategory', () => {
+    it('should update a category successfully', async () => {
+      const categoryId = '1';
+      const updateData = { name: 'Updated Category' };
+      const updatedCategory = { _id: categoryId, ...updateData };
+      (CategoryModel.findByIdAndUpdate as any).mockResolvedValue(updatedCategory);
+
+      const result = await updateCategory(categoryId, updateData);
+
+      expect(result).toEqual(updatedCategory);
+      expect(CategoryModel.findByIdAndUpdate).toHaveBeenCalledWith(categoryId, updateData, { new: true });
+    });
+
+    it('should handle error during category update', async () => {
+      const categoryId = '1';
+      const updateData = { name: 'Updated Category' };
+      (CategoryModel.findByIdAndUpdate as any).mockImplementation(() => {
+        throw new Error('Error updating category');
+      });
+
+      await expect(updateCategory(categoryId, updateData)).rejects.toThrow('Error updating category');
+    });
+  });
+
+  describe('deleteCategory', () => {
+    it('should delete a category successfully', async () => {
+      const categoryId = '1';
+      const category = { _id: categoryId, parentId: null, children: [] };
+      (CategoryModel.findById as any).mockResolvedValue(category);
+      (CategoryModel.deleteOne as any).mockResolvedValue({});
+
+      await deleteCategory(categoryId);
+
+      expect(CategoryModel.findById).toHaveBeenCalledWith(categoryId);
+      expect(CategoryModel.deleteOne).toHaveBeenCalledWith({ _id: categoryId });
+    });
+
+    it('should handle error during category deletion', async () => {
+      const categoryId = '1';
+      (CategoryModel.findById as any).mockImplementation(() => {
+        throw new Error('Error deleting category');
+      });
+
+      await expect(deleteCategory(categoryId)).rejects.toThrow('Error deleting category');
+    });
+  });
+
+  describe('getTree', () => {
+    it('should retrieve the category tree successfully', async () => {
+      const categories = [
+        { _id: '1', name: 'Category 1', parentId: null, children: [] },
+        { _id: '2', name: 'Category 2', parentId: '1', children: [] },
+      ];
+      (CategoryModel.find as any).mockResolvedValue(categories);
+
+      const result = await getTree();
+
+      expect(result).toEqual([
+        { _id: '1', name: 'Category 1', parentId: null, children: [{ _id: '2', name: 'Category 2', parentId: '1', children: [] }] },
+      ]);
+      expect(CategoryModel.find).toHaveBeenCalled();
+    });
+
+    it('should handle error during category tree retrieval', async () => {
+      (CategoryModel.find as any).mockImplementation(() => {
+        throw new Error('Error retrieving category tree');
+      });
+
+      await expect(getTree()).rejects.toThrow('Error retrieving category tree');
+    });
+  });
+});


### PR DESCRIPTION
Add Jest test cases, Dockerfile, Kubernetes deployment, and Postman collection for category management API.

**Jest Test Cases**
* Add `jest.config.js` for Jest configuration.
* Add `categoryService.test.ts` with test cases for `createCategory`, `updateCategory`, `deleteCategory`, and `getTree` functions.
* Add `categoryController.test.ts` with test cases for `createCategory`, `updateCategory`, `deleteCategory`, and `getCategoriesTree` methods.

**Dockerfile**
* Add Dockerfile to create a Docker image for the application.
* Use `node:23-alpine` as the base image.
* Copy necessary files and install dependencies.
* Expose port 3000 and start the application.

**Kubernetes Deployment**
* Add `deployment.yaml` to define deployment for the application using the Docker image.
* Set replicas, container ports, and environment variables.
* Add `service.yaml` to define service to expose the application.
* Set service type and ports.

**Postman Collection**
* Add `postman_collection.json` to test all the APIs.
* Include requests for creating, updating, deleting, and getting categories.
* Include request for getting categories tree.

